### PR TITLE
Update __main__.py to store auto_adjust_urgency argument

### DIFF
--- a/taskcheck/__main__.py
+++ b/taskcheck/__main__.py
@@ -49,7 +49,9 @@ arg_parser.add_argument(
 )
 arg_parser.add_argument(
     "--no-auto-adjust-urgency",
-    action="store_true",
+    dest="auto_adjust_urgency",    # Argument we want to manipulate
+    action="store_false",          # If the flag is passed, set value to False 
+    default=True,                  # If the flag is not passed, set value to True by default
     help="disable automatically reduction of urgency weight when tasks cannot be completed on time",
 )
 


### PR DESCRIPTION
If ```--no-auto-adjust-urgency``` flag is passed, set the argument ```auto_adjust_urgency``` to ```True``` instead of creating an argument called ```no_auto_adjust_urgency``` which isn't otherwise used.

Separate pull request to follow that will modify the ```test_main.py``` test case to accommodate.  ```parallel.py``` already looks for ```auto_adjust_urgency```.